### PR TITLE
Properly handle Release and AddRef

### DIFF
--- a/include/D3D9Hook.hpp
+++ b/include/D3D9Hook.hpp
@@ -6,12 +6,21 @@
 
 #define D3D9_VTABLE_SIZE 119
 
+#define SAFE_RELEASE(d) \
+    if (d)              \
+    {                   \
+        d->Release();   \
+        d = NULL;       \
+    }
+
 typedef struct ShaderAndBuffer
 {
     IDirect3DPixelShader9* pixelShader;
     ID3DXBuffer* dxBuffer;
 } ShaderAndBuffer;
 
+typedef ULONG(WINAPI* tAddRef)(LPDIRECT3DDEVICE9 pDevice);
+typedef ULONG(WINAPI* tRelease)(LPDIRECT3DDEVICE9 pDevice);
 typedef HRESULT(WINAPI* tReset)(LPDIRECT3DDEVICE9 pDevice, D3DPRESENT_PARAMETERS* pPresentationParameters);
 typedef HRESULT(APIENTRY* tEndScene)(LPDIRECT3DDEVICE9 pDevice);
 typedef HRESULT(WINAPI* tDrawIndexedPrimitive)(LPDIRECT3DDEVICE9 pDevice, D3DPRIMITIVETYPE Type, INT BaseVertexIndex,
@@ -19,11 +28,17 @@ typedef HRESULT(WINAPI* tDrawIndexedPrimitive)(LPDIRECT3DDEVICE9 pDevice, D3DPRI
 typedef HRESULT(WINAPI* tSetStreamSource)(LPDIRECT3DDEVICE9 pDevice, UINT StreamNumber,
                                           IDirect3DVertexBuffer9* pStreamData, UINT OffsetInBytes, UINT Stride);
 
+void PreShutdown();
+
+extern tAddRef oAddRef;
+extern tRelease oRelease;
 extern tReset oReset;
 extern tEndScene oEndScene;
 extern tDrawIndexedPrimitive oDrawIndexedPrimitive;
 extern tSetStreamSource oSetStreamSource;
 
+ULONG WINAPI xAddRef(LPDIRECT3DDEVICE9 pDevice);
+ULONG WINAPI xRelease(LPDIRECT3DDEVICE9 pDevice);
 HRESULT WINAPI xReset(LPDIRECT3DDEVICE9 pDevice, D3DPRESENT_PARAMETERS* pPresentationParameters);
 HRESULT APIENTRY xEndScene(LPDIRECT3DDEVICE9 pDevice);
 HRESULT WINAPI xDrawIndexedPrimitive(LPDIRECT3DDEVICE9 pDevice, D3DPRIMITIVETYPE Type, INT BaseVertexIndex,
@@ -32,3 +47,4 @@ HRESULT WINAPI xSetStreamSource(LPDIRECT3DDEVICE9 pDevice, UINT StreamNumber, ID
                                 UINT OffsetInBytes, UINT Stride);
 
 bool InitD3D9Hook(void* d3d9Device[D3D9_VTABLE_SIZE]);
+bool ShutdownD3D9Hook();

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -21,6 +21,7 @@ DWORD WINAPI Init(LPVOID lpThreadParameter)
     return 0;
 }
 
+
 BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpReserved)
 {
     HANDLE hThread;
@@ -38,9 +39,14 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpReserved)
             }
 
             CloseHandle(hThread);
-        case DLL_THREAD_ATTACH:
-        case DLL_THREAD_DETACH:
+            break;
+
         case DLL_PROCESS_DETACH:
+            if (!ShutdownD3D9Hook())
+            {
+                return FALSE;
+            }
+
             break;
     }
 


### PR DESCRIPTION
Properly remove detours on DLL unload. Intercept and track refcount off the game's Direct3DDevice, when this is expected to be 0 by the game, destroy our shaders